### PR TITLE
Update spring.factories

### DIFF
--- a/cornerstone/src/main/resources/META-INF/spring.factories
+++ b/cornerstone/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,3 @@
 # Auto Configure
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.ctrip.framework.vi.spring.AutoConfiguration
+com.ctrip.framework.cs.spring.AutoConfiguration


### PR DESCRIPTION
修复开源版本未修改spring.factories内的自动装载包路径，导致抛java.io.FileNotFoundException: class path resource [com/ctrip/framework/vi/spring/AutoConfiguration.class] cannot be opened because it does not exist的异常